### PR TITLE
Poetry based package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "kcare-uchecker"
+version = "0.1.0-beta.0"
+description = "A simple tool to detect outdated shared libraries"
+authors = ["Rinat Sabitov <rinat.sabitov@gmail.com>"]
+license = "GPL-2.0-only"
+packages = [
+    { include = "uchecker.py" },
+]
+
+[tool.poetry.dependencies]
+python = "^3.8|^2.7"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.poetry.scripts]
+uchecker = 'uchecker:main'
+


### PR DESCRIPTION
We need a simple tool to build and distribute a package that contains the script. Poetry is a decent way to do that.
- build a simple package with one script `poetry build`
- simple version bumping

Also a minimal .gitignore file was added