### PR TITLE
Fix #6 Python 3.8 compatible Linux distribution name detection 

### DIFF
--- a/uchecker.py
+++ b/uchecker.py
@@ -62,9 +62,9 @@ def linux_distribution():
         for line in fd:
             name, _, value = line.partition('=')
             if name == 'ID':
-                distro_id = value.strip()
+                distro_id = value.strip().strip('"')
             elif name == 'VERSION_ID':
-                distro_version_id = value('"').strip()
+                distro_version_id = value.strip().strip('"')
     return distro_id + distro_version_id
 
 


### PR DESCRIPTION
platform.linux_distribution is deprecated for 3.8 so we have to implement our own methods like reading and parsing /etc/os-release file