### PR TITLE
Fix #8 File access error wrapping

### DIFF
--- a/uchecker.py
+++ b/uchecker.py
@@ -33,7 +33,6 @@ import struct
 import logging
 
 from collections import namedtuple
-from contextlib import contextmanager
 
 ELF64_HEADER = "<16sHHIQQQIHHHHHH"
 ELF_PH_HEADER = "<IIQQQQQQ"


### PR DESCRIPTION
When mmaped file has wrong maps or a regular file has access
restriction, the script should not stop and proceed with the rest.