### PR TITLE
Use libcare-client as a data source

### DIFF
--- a/tests/test_kernelcare.py
+++ b/tests/test_kernelcare.py
@@ -4,12 +4,17 @@ import uchecker
 
 LIBCARE_INFO_OUT = '{"pid": 20025, "comm": "sshd" , '\
     '"libc-2.17.so": {"buildid": "f9fafde281e0e0e2af45911ad0fa115b64c2cea8", "patchlvl": 2021021205}, '\
+    '"libcrypto.so.1.0.2k": {"buildid": "4cf1939f660008cfa869d8364651f31aacd2c1c4", "patchlvl": 2021012902}}\n'\
+    'some error\n'\
+    '{"pid": 20026, "comm": "php" , '\
+    '"libc-2.17.so": {"buildid": "f9fafde281e0e0e2af45911ad0fa115b64c2ce10", "patchlvl": 2021021205}, '\
     '"libcrypto.so.1.0.2k": {"buildid": "4cf1939f660008cfa869d8364651f31aacd2c1c4", "patchlvl": 2021012902}}'
 
 
-def tests_get_patched_data(tmpdir):
+@mock.patch('uchecker.os.system', return_value=0)
+def tests_get_patched_data(mock_system, tmpdir):
     libcare_ctl = tmpdir.join('libcare_ctl')
-    with mock.patch('uchecker.LIBCARE_CTL', str(libcare_ctl)):
+    with mock.patch('uchecker.LIBCARE_CLIENT', str(libcare_ctl)):
         # Kernelare tools does not exist
         libcare_ctl.ensure(file=0)
         assert uchecker.get_patched_data() == set()
@@ -21,7 +26,9 @@ def tests_get_patched_data(tmpdir):
         with mock.patch('uchecker.check_output', return_value=LIBCARE_INFO_OUT):
             assert uchecker.get_patched_data() == {
                 (20025, '4cf1939f660008cfa869d8364651f31aacd2c1c4'),
-                (20025, 'f9fafde281e0e0e2af45911ad0fa115b64c2cea8')
+                (20025, 'f9fafde281e0e0e2af45911ad0fa115b64c2cea8'),
+                (20026, '4cf1939f660008cfa869d8364651f31aacd2c1c4'),
+                (20026, 'f9fafde281e0e0e2af45911ad0fa115b64c2ce10')
             }
 
 


### PR DESCRIPTION
Libcare's server will output inconsistant output, so we need to parse
json only. Also we should not disturb `libcare info` if the server is
not running.