### PR TITLE
 Ignore not fully mapped files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ $ curl -s -L https://kernelcare.com/uchecker | sudo LOGLEVEL=debug python
 ```
 
 ## About
-The project is part of [kernelcare.com](https://kernelcare.com "KernelCare") - livepatching solution for linux kernels as well as shared libraries like glibc and openssl
+The project is part of [tuxcare.com](https://tuxcare.com "TuxCare") - livepatching solution for linux kernels as well as shared libraries like glibc and openssl

--- a/uchecker.py
+++ b/uchecker.py
@@ -346,7 +346,7 @@ class FileMMapped(object):
         for rng in self.vmas:
             if rng.offset <= offset < rng.offset + rng.size:
                 return rng
-        raise ValueError("Offset {0} is not in ranges {1}".format(offset, self.vmas))
+        raise IOError("Offset {0} is not in ranges {1}".format(offset, self.vmas))
 
     def tell(self):
         return self.pos
@@ -414,7 +414,7 @@ def iter_proc_lib():
             try:
                 with get_fileobj(pid, inode, pathname) as fileobj:
                     cache[inode] = get_build_id(fileobj)
-            except (NotAnELFException, BuildIDParsingException) as err:
+            except (NotAnELFException, BuildIDParsingException, IOError) as err:
                 logging.info("Can't read buildID from {0}: {1}".format(pathname, repr(err)))
                 cache[inode] = None
             except Exception as err:


### PR DESCRIPTION
In some cases process could load file only partially and there is a
challenge to know for sure what kind of file is it.

We will skip it.