### PR TITLE
refactor: conditional installation of mock (#53)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pytest = [
 ]
 flake8 = "^3.9.2"
 pytest-coverage = "*"
-mock = { version = "*", markers = "python_version < '3.3'" }
+mock = { version = "*", markers = "python_version < '3.8'" }
 more-itertools = "*"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ pytest = [
 ]
 flake8 = "^3.9.2"
 pytest-coverage = "*"
-mock = "*"
+mock = { version = "*", markers = "python_version < '3.3'" }
 more-itertools = "*"
 
 [build-system]

--- a/tests/test_kernelcare.py
+++ b/tests/test_kernelcare.py
@@ -1,12 +1,15 @@
-import pytest
-import mock
-
-import uchecker
-
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
+
+import pytest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import uchecker
 
 
 LIBCARE_INFO_OUT = '{"pid": 20025, "comm": "sshd" , '\

--- a/tests/test_kernelcare.py
+++ b/tests/test_kernelcare.py
@@ -1,13 +1,15 @@
+import sys
+
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 
 import pytest
-try:
-    from unittest import mock
-except ImportError:
+if sys.version_info < (3, 8):
     import mock
+else:
+    from unittest import mock
 
 import uchecker
 


### PR DESCRIPTION
This commit aims to close #53.

Description of updates:
1. Add `markers = "python_version < '3.3'"` for 'mock' package in pyproject.toml. It makes the package to be installed only for versions older than 3.3.
2. Update [import statements](https://github.com/cloudlinux/kcare-uchecker/blob/master/tests/test_kernelcare.py#L2) in test module, make it try to import mock from unittest first.
3. Update [imports order](https://peps.python.org/pep-0008/#imports) there as well, make it follow the next order: first python's standard library, second 3rd-party packages, third local modules and packages.

I've tested the above changes manually: 
1. Switch to python 2.7 (for example), install poetry, run `poetry install`. Then package 'mock' will be installed.
2. Switch to python 3.10, install poetry, run `poetry install`. Package 'mock' won't be installed.

___

* (chore): add markers for mock package in pyproject.toml
* (refactor): try to import mock from unittest first
* (refactor): update imports order according to pep08
  see: https://peps.python.org/pep-0008/#imports